### PR TITLE
Missing kwargs parameter added to Renderer constructor

### DIFF
--- a/pyldapi/register_renderer.py
+++ b/pyldapi/register_renderer.py
@@ -16,11 +16,22 @@ class RegisterRenderer(Renderer):
     """
     DEFAULT_ITEMS_PER_PAGE = 20
     
-    def __init__(self, request, uri, label, comment, register_items,
-                 contained_item_classes, register_total_count, *args,
-                 views=None, default_view_token=None, super_register=None,
-                 page_size_max=1000, register_template=None, 
-                 per_page=None, **kwargs):
+    def __init__(self, 
+                 request, 
+                 uri, 
+                 label, 
+                 comment, 
+                 register_items,
+                 contained_item_classes, 
+                 register_total_count, 
+                 *args,
+                 views=None, 
+                 default_view_token=None, 
+                 super_register=None,
+                 page_size_max=1000, 
+                 register_template=None, 
+                 per_page=None, 
+                 **kwargs):
         """
         Constructor
 
@@ -75,6 +86,7 @@ class RegisterRenderer(Renderer):
         self.page_size_max = page_size_max
         self.register_template = register_template
         self.paging_error = self._paging()
+        self.template_extras = kwargs
 
         try:
             self.format = self._get_requested_format()
@@ -183,6 +195,8 @@ class RegisterRenderer(Renderer):
             'super_register': self.super_register,
             'pagination': pagination
         }
+        if self.template_extras is not None:
+            _template_context.update(self.template_extras)
         if template_context is not None and isinstance(template_context, dict):
             _template_context.update(template_context)
 

--- a/pyldapi/renderer.py
+++ b/pyldapi/renderer.py
@@ -31,7 +31,14 @@ class Renderer(object, metaclass=ABCMeta):
         "text/plain": "nt",  # text/plain is the old/deprecated mimetype for n-triples
     }
 
-    def __init__(self, request, uri, views, default_view_token, alternates_template=None):
+    def __init__(self, 
+                 request, 
+                 uri, 
+                 views, 
+                 default_view_token, 
+                 alternates_template=None, 
+                 **kwargs
+                 ):
         """
         Constructor
 


### PR DESCRIPTION
G'day Nick & Edmond...

This small change fixes a bug where the call to the Renderer constructor fails when one or more optional kwargs are specified. The base class constructor didn't have a '**kwargs' parameter, but the RegisterRenderer constructor still passes optional keywords through to the superclass constructor. I have also added the code to update the _template_context dict from the kwargs.

This fix is necessary to enable something like a register search without subclassing RegisterRenderer (as has been done in VocPrez with the SkosRegisterRenderer class). The bug showed up when I tried to implement a search in the Placenames register, which uses a RegisterRenderer object.

I've also changed the cosmetic layout of the function parameters to place them one per line, just for readability.

Feel free to squash the commits - I should have done it in a single commit, anyway.

Cheers,

Alex