### PR TITLE
Fixed last_page ceiling function

### DIFF
--- a/pyldapi/fastapi_framework/renderer_container.py
+++ b/pyldapi/fastapi_framework/renderer_container.py
@@ -127,7 +127,7 @@ class ContainerRenderer(Renderer):
 
     def _paging(self):
         # calculate last page
-        self.last_page = int(round(self.members_total_count / self.per_page, 0)) + 1  # same as math.ceil()
+        self.last_page = self.members_total_count // self.per_page + bool(self.members_total_count % self.per_page)  # same as math.ceil()
 
         # if we've gotten the last page value successfully, we can choke if someone enters a larger value
         if self.page > self.last_page:


### PR DESCRIPTION
Original ceiling function rounded last_page up to the next integer if the number of members on the last page was over half of per_page. This resulted in the last page being empty while the second last page had a member count of less than per_page.